### PR TITLE
fix(gsb monitoring icon) throwing status errors

### DIFF
--- a/src/components/GlobalStatusBar/GlobalStatusBar.tsx
+++ b/src/components/GlobalStatusBar/GlobalStatusBar.tsx
@@ -57,7 +57,11 @@ const GlobalStatusBar = () => {
       <RuxClock />
 
       <div className='Global-status-bar__status-indicators' slot='right-side'>
-        <RuxMonitoringProgressIcon label='UCA' progress={ucaCount} range={[]} />
+        <RuxMonitoringProgressIcon
+          label='UCA'
+          progress={ucaCount}
+          range={[{ threshold: 100, status: 'off' }]}
+        />
         <RuxPopUp placement='bottom'>
           <RuxMenu>
             <AlertPopUp softwareAlerts={softwareAlerts} />


### PR DESCRIPTION
The monitoring icon in the GSB was throwing errors. I believe this is because `status={[]}` requires an object consisting of a threshold and the status. So I gave it one that is inline with how it was behaving.