### PR TITLE
fix(alert-list): removing border-bottom from each alert and unneeded hover style

### DIFF
--- a/src/components/AlertsPanel/Alerts.css
+++ b/src/components/AlertsPanel/Alerts.css
@@ -52,6 +52,12 @@
   visibility: hidden;
 }
 
+.alert-list_no-alerts {
+  display: flex;
+  justify-content: center;
+  margin-block-start: var(--spacing-24);
+}
+
 .table-wrapper.alert-list::-webkit-scrollbar-track {
   margin-top: 0;
 }

--- a/src/components/AlertsPanel/Alerts.css
+++ b/src/components/AlertsPanel/Alerts.css
@@ -58,14 +58,6 @@
 
 /* ACCORDION ITEM STYLES */
 
-/* .alerts rux-accordion-item::part(label-wrapper) {
-  flex-direction: row-reverse;
-}
-
-.alerts rux-accordion-item::part(indicator) {
-  transform: rotate(-90deg);
-} */
-
 .alert-list-label {
   display: flex;
   flex-flow: row nowrap;

--- a/src/components/AlertsPanel/Alerts.css
+++ b/src/components/AlertsPanel/Alerts.css
@@ -56,6 +56,10 @@
   visibility: hidden;
 }
 
+.alert-list-headers span[data-sortprop] {
+  cursor: pointer;
+}
+
 .alert-list_no-alerts {
   display: flex;
   justify-content: center;

--- a/src/components/AlertsPanel/Alerts.css
+++ b/src/components/AlertsPanel/Alerts.css
@@ -42,12 +42,16 @@
 
 .alert-list-headers rux-icon {
   vertical-align: middle;
-  width: 32px;
+  width: 24px;
+  height: 24px;
 }
 
-.alert-list-headers rux-icon.visible {
+.alert-list-headers rux-icon.visible,
+.alert-list-headers span[data-sortprop]:hover rux-icon {
   visibility: visible;
+  position: absolute;
 }
+
 .alert-list-headers rux-icon.hidden {
   visibility: hidden;
 }

--- a/src/components/AlertsPanel/AlertsList.tsx
+++ b/src/components/AlertsPanel/AlertsList.tsx
@@ -143,9 +143,13 @@ const AlertsList = ({ severitySelection, categorySelection }: PropTypes) => {
         </span>
       </div>
       <ul className='alert-list'>
-        {displayAlertIds.map((id) => (
-          <AlertListItem alertItem={alerts[id]} key={id} />
-        ))}
+        {displayAlertIds.length > 0 ? (
+          displayAlertIds.map((id) => (
+            <AlertListItem alertItem={alerts[id]} key={id} />
+          ))
+        ) : (
+          <div className='alert-list_no-alerts'>No alerts at this time.</div>
+        )}
       </ul>
     </>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -7,12 +7,6 @@ ul {
 
 li {
   list-style-type: none;
-  border-bottom: 1px solid var(--color-background-base-default);
-}
-
-li:hover {
-  background-color: var(--color-background-surface-hover);
-  cursor: pointer;
 }
 
 h1 {


### PR DESCRIPTION
This PR makes the following adjustments to the alert list from the design audit:

- Fixes the accordion and list item styles to match Command (removes extra hover state color and extra border)
- Adds in a 'no alerts shown' message if there are no alerts
- Adjusts the sorting header items so the caret shows on hover and always shows even if the label is truncated.
- [JIRA Ticket](https://rocketcom.atlassian.net/browse/DEMO-250)