### PR TITLE
fix(table): making table caret appear next to ellipsed text on click

### DIFF
--- a/src/common/Table/Table.css
+++ b/src/common/Table/Table.css
@@ -11,7 +11,12 @@
   vertical-align: middle;
 }
 
-.table-wrapper rux-table-header-row .visible {
+.table-wrapper rux-table-header-row rux-table-header-cell:hover {
+  cursor: pointer;
+}
+
+.table-wrapper rux-table-header-row .visible,
+.table-wrapper rux-table-header-row rux-table-header-cell:hover rux-icon {
   visibility: visible;
 }
 
@@ -33,7 +38,8 @@
   grid-template-columns: 100% 0%;
 }
 
-.table-wrapper rux-table-header-cell:has(rux-icon.visible) div {
+.table-wrapper rux-table-header-cell:has(rux-icon.visible) div,
+.table-wrapper rux-table-header-cell:hover div {
   grid-template-columns: auto 1fr;
 }
 
@@ -43,23 +49,9 @@
   text-overflow: ellipsis;
 }
 
-.table-wrapper rux-table-header-cell[data-sortprop='status'] {
-  text-align: center;
-}
-
-.table-wrapper
-  rux-table-header-cell[data-sortprop='status']:has(rux-icon.visible)
-  div {
-  /* This is so the status header label doesn't move when selected. */
-  margin-inline-start: 34px;
-}
-
-.Dashboard-page__right-top-panel
-  .table-wrapper
-  rux-table-header-cell[data-sortprop='status']:has(rux-icon.visible)
-  div {
-  /* This is so the status header label has room when selected on the smaller table in the Dashboard */
-  margin-inline-start: 0px;
+.table-wrapper rux-table-cell rux-status {
+  margin-inline-start: calc(var(--spacing-4) + var(--spacing-050));
+  width: fit-content;
 }
 
 rux-container .table-wrapper {

--- a/src/common/Table/Table.css
+++ b/src/common/Table/Table.css
@@ -54,6 +54,14 @@
   margin-inline-start: 34px;
 }
 
+.Dashboard-page__right-top-panel
+  .table-wrapper
+  rux-table-header-cell[data-sortprop='status']:has(rux-icon.visible)
+  div {
+  /* This is so the status header label has room when selected on the smaller table in the Dashboard */
+  margin-inline-start: 0px;
+}
+
 rux-container .table-wrapper {
   /* to color small space above scrollbar */
   background-color: var(--color-background-base-header);

--- a/src/common/Table/Table.css
+++ b/src/common/Table/Table.css
@@ -9,15 +9,10 @@
 
 .table-wrapper rux-table-header-row rux-icon {
   vertical-align: middle;
-  /* width: 32px; */
 }
 
 .table-wrapper rux-table-header-row .visible {
   visibility: visible;
-}
-
-.table-wrapper rux-table-header-cell:has(rux-icon.visible) {
-  color: var(--color-text-interactive-default);
 }
 
 .table-wrapper rux-table-header-row .hidden {
@@ -32,12 +27,31 @@
   text-overflow: ellipsis;
 }
 
-.table-wrapper rux-table-cell rux-status {
-  padding-right: var(--spacing-8);
+.table-wrapper rux-table-header-cell div {
+  display: grid;
+  align-items: center;
+  grid-template-columns: 100% 0%;
+}
+
+.table-wrapper rux-table-header-cell:has(rux-icon.visible) div {
+  grid-template-columns: auto 1fr;
+}
+
+.table-wrapper rux-table-header-cell span {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .table-wrapper rux-table-header-cell[data-sortprop='status'] {
   text-align: center;
+}
+
+.table-wrapper
+  rux-table-header-cell[data-sortprop='status']:has(rux-icon.visible)
+  div {
+  /* This is so the status header label doesn't move when selected. */
+  margin-inline-start: 34px;
 }
 
 rux-container .table-wrapper {

--- a/src/common/Table/TableBodyRow.tsx
+++ b/src/common/Table/TableBodyRow.tsx
@@ -19,7 +19,6 @@ const ContactsTable = ({ columnDefs, rowData, handleRowClick }: PropTypes) => {
           : rowData[property];
         return (
           <RuxTableCell
-            className={colDef.isRightAligned ? 'right-align' : ''}
             key={colDef.label}
           >
             {property === 'status' ? (

--- a/src/common/Table/TableHeaderCell.tsx
+++ b/src/common/Table/TableHeaderCell.tsx
@@ -19,16 +19,22 @@ const TableHeaderCell = ({
     <RuxTableHeaderCell
       data-sortprop={columnDefinition.property}
       onClick={handleClick}
-      className={columnDefinition.isRightAligned ? 'right-align' : ''}
+      className={columnDefinition.property === 'status' ? 'status-align' : ''}
     >
-      {columnDefinition.label}
+      <div>
+        <span>
+        {columnDefinition.label}
+        </span>
+      
       <RuxIcon
         icon={sortDirection === 'ASC' ? 'arrow-drop-down' : 'arrow-drop-up'}
-        size='small'
+        size='32px'
         className={
           sortProp === columnDefinition.property ? 'visible' : 'hidden'
         }
       />
+      </div>
+      
     </RuxTableHeaderCell>
   );
 };

--- a/src/components/CurrentContactsPanel/CurrentContactsTable.css
+++ b/src/components/CurrentContactsPanel/CurrentContactsTable.css
@@ -30,11 +30,3 @@
   vertical-align: middle;
   width: 32px;
 }
-
-.table-wrapper rux-table-header-row .visible {
-  visibility: visible;
-}
-
-.table-wrapper rux-table-header-row .hidden {
-  visibility: hidden;
-}


### PR DESCRIPTION
This PR is a fix for the Contacts Table (in both places it appears) to change the  active row filtering caret behavior. It includes:

- Change to Status header alignment and ensuing change to the rux-status cells to make them look centered.
- Sorting carets appearing on hover, table header item getting hand cursor on hover.
- Re doing the html for the header to have conditional spacing for the caret so that it can appear on active/hover and sit right next to ellipses text when header text is truncated.

[JIRA Ticket](https://rocketcom.atlassian.net/browse/DEMO-253)