### PR TITLE
fix(equipment string panel): design audit updates

### DIFF
--- a/src/components/ContactDetails/ContactDetails.css
+++ b/src/components/ContactDetails/ContactDetails.css
@@ -6,6 +6,11 @@
   gap: var(--spacing-4);
 }
 
+.Contact-details-grid__equipment-string .config-grid-wrapper {
+  width: 50%;
+  padding-block-end: var(--spacing-2);
+}
+
 .Contact-details-grid__equipment-string .sub-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);

--- a/src/components/ContactDetails/ContactDetails.css
+++ b/src/components/ContactDetails/ContactDetails.css
@@ -12,6 +12,10 @@
   gap: var(--spacing-4);
 }
 
+rux-container.Contact-details-grid__equipment-string::part(footer) {
+  border-top: 1px solid var(--container-color-border);
+}
+
 .contact-details-sat {
   display: flex;
   gap: var(--spacing-2);

--- a/src/components/ContactDetails/ContactDetails.tsx
+++ b/src/components/ContactDetails/ContactDetails.tsx
@@ -304,7 +304,9 @@ const ContactDetails = () => {
 
           <RuxContainer className='Contact-details-grid__equipment-string'>
             <header>Equipment String</header>
-            <DetailsGrid details={configDetails} />
+            <div className="config-grid-wrapper">
+              <DetailsGrid details={configDetails} />
+            </div>
 
             <span>{contact.equipment}</span>
 

--- a/src/components/ContactDetails/EquipmentIcons/EquipmentIcons.css
+++ b/src/components/ContactDetails/EquipmentIcons/EquipmentIcons.css
@@ -5,3 +5,7 @@
   justify-content: flex-start;
   gap: 0.7rem;
 }
+
+.equipment-icons rux-icon {
+  color: var(--color-text-primary);
+}

--- a/src/components/ContactDetails/EquipmentIcons/EqupimentIcons.tsx
+++ b/src/components/ContactDetails/EquipmentIcons/EqupimentIcons.tsx
@@ -1,4 +1,5 @@
-import { RuxMonitoringIcon } from '@astrouxds/react';
+import { RuxIcon, RuxMonitoringIcon } from '@astrouxds/react';
+import { Fragment } from 'react';
 
 import './EquipmentIcons.css';
 
@@ -9,14 +10,18 @@ type PropTypes = {
 const EquipmentIcons = ({ equipmentString }: PropTypes) => {
   return (
     <div className='equipment-icons'>
-      {equipmentString.split(' ').map((equipmentSubString: string) => (
-        <RuxMonitoringIcon
-          key={equipmentSubString}
-          status='normal'
-          icon='center-focus-weak'
-          label={equipmentSubString}
-        />
-      ))}
+      {equipmentString
+        .split(' ')
+        .map((equipmentSubString: string, index: number) => (
+          <Fragment key={equipmentSubString}>
+            {index !== 0 && <RuxIcon icon='arrow-right-alt' />}
+            <RuxMonitoringIcon
+              status='normal'
+              icon='center-focus-weak'
+              label={equipmentSubString}
+            />
+          </Fragment>
+        ))}
     </div>
   );
 };


### PR DESCRIPTION
[JIRA Ticket](https://rocketcom.atlassian.net/browse/DEMO-254)
This ticket includes the following fixes from the design audit:

- Adding a border between the equipment string and ANT 1 sections
- Adjusting the config select menu and label to match the parameter ones below, adding some bottom padding
- Adding arrow between the equipment icons